### PR TITLE
Relax semver range to fix error in AST transformer

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "eslint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "remark-github-plugin": "1.1.0"
+    "remark-github-plugin": "^1.1.0"
   },
   "devDependencies": {
     "@cid-harvard/eslint-config": "0.1.2",


### PR DESCRIPTION
Version 1.1 of `remark-github-plugin`, which this plugin depends on, has
an error that was fixed by v1.1.1. This commit relaxes the version range
so that fix can "flow" through. That is also a good practice if
dependencies obey semver.